### PR TITLE
[don't-merge] fix: add global chunk-prover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3970,6 +3970,7 @@ dependencies = [
  "itertools",
  "log",
  "log4rs",
+ "once_cell",
  "prover",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ ethers-providers = "1.0"
 itertools = "0.10.5"
 log = "0.4"
 log4rs = { version = "1.2.0", default_features = false, features = ["console_appender", "file_appender"] }
+once_cell = "1.8"
 reqwest = { version = "0.11", default-features = false, features = [ "json", "rustls-tls" ] }
 serde = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
### Summary

@noel2004 mentioned that there is performance issue on chunk-prove.
Fix to use a global chunk-prover to avoid duplicate params loading and pk generating.